### PR TITLE
When adding a submodule try doing so over https

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -52,6 +52,7 @@ jobs:
       run: |
         # Add submodule
         if [ ! -d "stack-${STACK}" ]; then
+          git config --global url."https://github.com/".insteadOf git@github.com:
           git submodule add git@github.com:fedjabosnic/tf-stack-${STACK}.git stack-${STACK}
           git submodule update --remote
           echo " ${STACK}" >> .variables/stacks


### PR DESCRIPTION
* Git inside the github action appears to have the special github key that has access only to its own repos
* We have an access token that has wider access but these are only usable over https not ssh
* It would be better if we could avoid adding an ssh key just for the case of adding submodules
* Despite this it is preferable if the submodules use ssh as this works better locally
* Try forcing git to use https instead of ssh then add the submodule as ssh as before